### PR TITLE
Raise errors for bad values

### DIFF
--- a/reference.rb
+++ b/reference.rb
@@ -4,11 +4,14 @@ require_relative 'trie'
 
 class Reference
   include Singleton
-  attr_reader :codepoint_to_data, :name_to_data, :alias_to_name
+  attr_reader :codepoint_to_data, :name_to_codepoint, :alias_to_name
+
+  class AmbiguousName < StandardError; end
+  class NoSuchCharacter < StandardError; end
 
   def initialize(data_source=UnicodeData.instance)
     @codepoint_to_data = data_source.cp_hash
-    @name_to_data = data_source.trie
+    @name_to_codepoint = data_source.trie
     @alias_to_name = data_source.alias_hash
   end
 
@@ -16,29 +19,43 @@ class Reference
     # -> String
     # Map a codepoint to the corresponding name.
 
-    val = @codepoint_to_data[codepoint]
-    val.correction.empty? ? val.name : val.correction
+    data = checkExistence(@codepoint_to_data[codepoint], codepoint)
+    data.correction.empty? ? data.name : data.correction
   end
 
   def character(name)
     # -> Codepoint
     # Map a string representing a name, or an alias, to a codepoint.
 
+    checkAmbiguity(name)
     official_name = @alias_to_name[name] || name
-    @name_to_data[official_name]
+    checkExistence(@name_to_codepoint[official_name], name)
   end
 
   def majorCategory(codepoint)
     # -> String
     # Map a codepoint to a string of length 1-3 that represents its major category.
 
-    @codepoint_to_data[codepoint].major_category
+    checkExistence(@codepoint_to_data[codepoint], codepoint).major_category
   end
 
   def category(codepoint)
     # -> String
     # Map a codepoint to a string of length 2 that represents its category.
 
-    @codepoint_to_data[codepoint].minor_category
+    checkExistence(@codepoint_to_data[codepoint], codepoint).minor_category
+  end
+
+  def checkExistence(character, request)
+    if character == nil
+      raise NoSuchCharacter, "No Unicode character corresponds with #{request}."
+    end
+    character
+  end
+
+  def checkAmbiguity(name)
+    if name == "<control>"
+      raise AmbiguousName, "<control> is an ambiguous Unicode 3.0 name-- instead use an alias."
+    end
   end
 end

--- a/test_unicode_reference_with_inline_data.rb
+++ b/test_unicode_reference_with_inline_data.rb
@@ -12,10 +12,14 @@ class ReferenceTestWithInlinedData < Test::Unit::TestCase
 
   # Called after every test method runs. Can be used to tear
   # down fixture information.
-
   def teardown
     # Do nothing
   end
+
+
+  #
+  # Basic functionality
+  #
 
   def test_codepoint_lookup
     null = @reference.character("NULL")
@@ -36,6 +40,11 @@ class ReferenceTestWithInlinedData < Test::Unit::TestCase
     null = @reference.category("0000")
     assert(null == "Cc")
   end
+
+
+  #
+  # Aliases
+  #
 
   def test_name_lookup_correction_alias
     name = @reference.name("01A2")
@@ -61,6 +70,11 @@ class ReferenceTestWithInlinedData < Test::Unit::TestCase
     cp = @reference.character("SINGLE GRAPHIC CHARACTER INTRODUCER")
     assert(cp == "0099")
   end
+
+
+  #
+  # Bad values
+  #
 
   def test_codepoint_lookup_control_char_no_alias
     assert_raise(Reference::AmbiguousName) do
@@ -91,5 +105,4 @@ class ReferenceTestWithInlinedData < Test::Unit::TestCase
       cp = @reference.category("Gobbledygook")
     end
   end
-
 end

--- a/test_unicode_reference_with_inline_data.rb
+++ b/test_unicode_reference_with_inline_data.rb
@@ -61,4 +61,35 @@ class ReferenceTestWithInlinedData < Test::Unit::TestCase
     cp = @reference.character("SINGLE GRAPHIC CHARACTER INTRODUCER")
     assert(cp == "0099")
   end
+
+  def test_codepoint_lookup_control_char_no_alias
+    assert_raise(Reference::AmbiguousName) do
+      cp = @reference.character("<control>")
+    end
+  end
+
+  def test_codepoint_lookup_bad_char
+    assert_raise(Reference::NoSuchCharacter) do
+      cp = @reference.character("Gobbledygook")
+    end
+  end
+
+  def test_name_lookup_bad_char
+    assert_raise(Reference::NoSuchCharacter) do
+      cp = @reference.name("Gobbledygook")
+    end
+  end
+
+  def test_major_category_lookup_bad_char
+    assert_raise(Reference::NoSuchCharacter) do
+      cp = @reference.majorCategory("Gobbledygook")
+    end
+  end
+
+  def test_category_lookup_bad_char
+    assert_raise(Reference::NoSuchCharacter) do
+      cp = @reference.category("Gobbledygook")
+    end
+  end
+
 end


### PR DESCRIPTION
Raise exception if a request is made with an ambiguous name, or
with a codepoint or name that does not correspond to any Unicode
character.
